### PR TITLE
Switch to jekyll_image_processing for performance.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ gem "minima", "~> 2.5"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
-	gem "jekyll-minimagick"
-	gem 'jekyll-exif-data', '~> 0.0'
+  gem "jekyll_image_processing", git: "https://github.com/benubois/jekyll_image_processing"
+  gem 'jekyll-exif-data', '~> 0.0'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/benubois/jekyll_image_processing
+  revision: 6b60d80dafe78a8fcff99db0e7fcc5203060bee1
+  specs:
+    jekyll_image_processing (0.1.0)
+      image_processing (>= 1.10.3)
+      jekyll (>= 0.10.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -15,6 +23,9 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    image_processing (1.10.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jekyll (4.0.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -34,9 +45,6 @@ GEM
       exifr (~> 1.3)
     jekyll-feed (0.13.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-minimagick (0.0.4)
-      jekyll (>= 0.10.0)
-      mini_magick (>= 3.3)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.6.1)
@@ -63,6 +71,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rouge (3.16.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     safe_yaml (1.0.5)
     sassc (2.2.1)
       ffi (~> 1.9)
@@ -83,7 +93,7 @@ DEPENDENCIES
   jekyll (~> 4.0.0)
   jekyll-exif-data (~> 0.0)
   jekyll-feed (~> 0.12)
-  jekyll-minimagick
+  jekyll_image_processing!
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/benubois/jekyll_image_processing
-  revision: 6b60d80dafe78a8fcff99db0e7fcc5203060bee1
+  revision: b76c215c135d5e2689c0adfbd619b278d0973209
   specs:
     jekyll_image_processing (0.1.0)
       image_processing (>= 1.10.3)

--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ image_processing:
   tint:
     source: photos/original
     destination: photos/tint
-    resize_to_limit: [1, 1]
+    resize_to_fill: [1,1]
 
 # exiftag:
 #  sources:

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 # For technical reasons, this file is *NOT* reloaded automatically when you use
 # 'bundle exec jekyll serve'. If you change this file, please restart the server process.
 #
-# If you need help with YAML syntax, here are some quick references for you: 
+# If you need help with YAML syntax, here are some quick references for you:
 # https://learn-the-web.algonquindesign.ca/topics/markdown-yaml-cheat-sheet/#yaml
 # https://learnxinyminutes.com/docs/yaml/
 #
@@ -31,22 +31,21 @@ instagram_username:  maxvoltar
 # Build settings
 plugins:
   - jekyll-feed
-  - jekyll-minimagick
   - jekyll-exif-data
 
-mini_magick:
+image_processing:
   large:
     source: photos/original
     destination: photos/large
-    resize: "2048x2048"
+    resize_to_limit: [2048, 2048]
   thumbnail:
     source: photos/original
     destination: photos/thumbnail
-    resize: "640x640"
+    resize_to_limit: [640, 640]
   tint:
     source: photos/original
     destination: photos/tint
-    resize: "1x1"
+    resize_to_limit: [1, 1]
 
 # exiftag:
 #  sources:

--- a/_plugins/bundler.rb
+++ b/_plugins/bundler.rb
@@ -1,21 +1,3 @@
-require "jekyll-minimagick"
-
-module Jekyll
-  module JekyllMinimagick
-    class GeneratedImageFile < Jekyll::StaticFile
-      def initialize(site, base, dir, name, preset)
-        @site = site
-        @base = base
-        @dir  = dir
-        @name = name
-        @dst_dir = preset.delete('destination')
-        @src_dir = preset.delete('source')
-        @commands = preset
-        
-        # jekyll-minimagick is missing these two instance variables
-        @relative_path = File.join(*[@dir, @name].compact)
-        @extname = File.extname(@name)
-      end
-    end
-  end
-end
+require "rubygems"
+require "bundler/setup"
+Bundler.require(:default)


### PR DESCRIPTION
This should speed up builds significantly. 

Locally:

```
done in 31.586 seconds.
```

On Netlify:

```
done in 130.055 seconds.
```

Here's the [docs for the new gem](https://github.com/benubois/jekyll_image_processing/blob/master/README.md) incase you want to add processing transformations.