### PR TITLE
Create a page for every photo.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,10 @@ gem "minima", "~> 2.5"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   # gem "jekyll-feed", "~> 0.12"
+  gem "exifr"
   gem "jekyll_image_processing", git: "https://github.com/benubois/jekyll_image_processing"
-  gem 'exifr'
-  gem 'jekyll-exif-data', '~> 0.0'
+  gem "jekyll-tidy"
+  gem "jekyll-exif-data", "~> 0.0"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/benubois/jekyll_image_processing
-  revision: b76c215c135d5e2689c0adfbd619b278d0973209
+  revision: 3c3dab7e979c29585361ce6b4e04ca91a404e058
   specs:
     jekyll_image_processing (0.1.0)
       image_processing (>= 1.10.3)
@@ -20,6 +20,8 @@ GEM
     exifr (1.3.6)
     ffi (1.12.2)
     forwardable-extended (2.6.0)
+    htmlbeautifier (1.3.1)
+    htmlcompressor (0.4.0)
     http_parser.rb (0.6.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
@@ -49,6 +51,10 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.6.1)
       jekyll (>= 3.3, < 5.0)
+    jekyll-tidy (0.2.2)
+      htmlbeautifier
+      htmlcompressor
+      jekyll
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.1.0)
@@ -93,7 +99,7 @@ DEPENDENCIES
   exifr
   jekyll (~> 4.0.0)
   jekyll-exif-data (~> 0.0)
-  jekyll-feed (~> 0.12)
+  jekyll-tidy
   jekyll_image_processing!
   minima (~> 2.5)
   tzinfo (~> 1.2)

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,20 +1,20 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-	<title>{{ site.title }}</title>
+	<title data-title="{{ site.title }}">{{ page.title | default: site.title }}</title>
 	<link rel="alternate" type="application/rss+xml" title="RSS Feed" href="{{ site.url }}/feed.xml">
-	<meta property="og:title" content="{{ site.title }}">
+	<meta property="og:title" content="{{ page.title | default: site.title }}">
 	<meta property="og:type" content="website">
-	<meta property="og:url" content="{{ site.url }}">
-	<meta property="og:image" content="{% assign images = site.static_files | photo_filter %}{% for image in images limit: 1 %}{{ site.url }}/photos/large/{{ image.name }}{% endfor %}">
+	<meta property="og:url" content="{{ site.url }}{{ page.url }}">
+	<meta property="og:image" content="{{ site.url }}{{ page.image | uri_escape | processed_path: 'large' }}">
 	<meta property="og:site_name" content="{{ site.title }}">
 	<meta property="og:description" content="{{ site.description }}">
-	<meta name="thumbnail" content="{% assign images = site.static_files | photo_filter %}{% for image in images limit: 1 %}{{ site.url }}/photos/large/{{ image.name }}{% endfor %}">
+	<meta name="thumbnail" content="{{ site.url }}{{ page.image | uri_escape | processed_path: 'large' }}">
 	<meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:site" content="{{ site.twitter_username }}">
-	<meta name="twitter:title" content="{{ site.title }}">
+	<meta name="twitter:title" content="{{ page.title | default: site.title }}">
 	<meta name="twitter:description" content="{{ site.description }}">
-	<meta name="twitter:image:src" content="{% assign images = site.static_files | photo_filter %}{% for image in images limit: 1 %}{{ site.url }}/photos/large/{{ image.name }}{% endfor %}">
+	<meta name="twitter:image:src" content="{{ site.url }}{{ page.image | uri_escape | processed_path: 'large' }}">
 	<meta name="description" content="{{ site.description }}">
 	<script type="text/javascript" src="/js/lazy-loading.js"></script>
 	<link rel="stylesheet" type="text/css" media="screen" href="/css/master.css" />

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -2,40 +2,79 @@
   const ESCAPE = 27;
   const RIGHT = 39;
   const LEFT = 37;
+  const TARGET_CLASS = 'target';
 
-  const clickButton = (buttonClass) => {
-    const id = window.location.hash && window.location.hash.replace(".", "\\.");
-    const selector = `li${id} ${buttonClass}`;
-    const button = document.querySelector(selector);
-    button && button.click();
+  const clickNavigationButton = (buttonClass) => {
+    const id = window.history.state && window.history.state.id;
+    if (id) {
+      const selector = `#${id} ${buttonClass}`;
+      const button = document.querySelector(selector);
+      button && button.click();
+    }
   }
 
-  const navigate = (event, buttonClass, property) => {
-    if (event.target.matches(buttonClass)) {
-      const button = event.target.closest("li")[property];
-      if (button) {
-        const id = `#${button.getAttribute('id')}`;
-        window.location = id;
-        console.log(`Going to ${buttonClass}: ${id}`);
-      }
+  const openPhoto = (id, pushState) => {
+    const photo = document.querySelector(`#${id}`);
+    const title = photo.getAttribute('title');
+    const href = `/${id}/`;
+    removeTargetClass();
+    photo.classList.add(TARGET_CLASS);
+    document.title = title;
+    if (pushState) {
+      window.history.pushState({id: id}, '', href);
+    }
+  }
+
+  const closePhoto = (pushState) => {
+    const title = document.querySelector('head title').getAttribute('data-title');
+    removeTargetClass();
+    document.title = title;
+    if (pushState) {
+      window.history.pushState({}, '', '/');
+    }
+  }
+
+  const removeTargetClass = () => {
+    let targets = document.querySelectorAll(`.${TARGET_CLASS}`);
+    targets.forEach((target) => {
+      target.classList.remove(TARGET_CLASS);
+    });
+  }
+
+  const handleClick = (selector, event, callback) => {
+    if (event.target.matches(selector)) {
+      callback();
       event.preventDefault();
     }
   }
 
-  document.addEventListener("keydown", (event) => {
+  window.onpopstate = function(event) {
+    if (event.state && event.state.id) {
+      const id = event.state.id;
+      openPhoto(id, false);
+    } else {
+      closePhoto(false);
+    }
+  }
+
+  document.addEventListener('keydown', (event) => {
     if (event.keyCode === ESCAPE) {
-      window.location = '#home';
-      console.log('Going #home');
+      closePhoto(true);
     } else if (event.keyCode === RIGHT) {
-      clickButton('.next');
+      clickNavigationButton('.next');
     } else if (event.keyCode === LEFT) {
-      clickButton('.previous');
+      clickNavigationButton('.previous');
     }
   });
 
   document.addEventListener('click', (event) => {
-    navigate(event, '.next', 'nextElementSibling');
-    navigate(event, '.previous', 'previousElementSibling');
+    handleClick('[data-target]', event, () => {
+      const id = event.target.getAttribute('data-target');
+      openPhoto(id, true);
+    });
+    handleClick('.close', event, () => {
+      closePhoto(true);
+    });
   });
 
   lazyload();

--- a/_includes/photo.html
+++ b/_includes/photo.html
@@ -1,17 +1,43 @@
-{% capture image_path %}photos/original/{{ image.name }}{% endcapture %}
+{% assign slug = image.name | strip_extension | slugify %}
+{% assign safe_name = image.name | uri_escape %}
+{% assign next_index = forloop.index0 | plus: 1 %}
+{% assign previous_index = forloop.index0 | minus: 1 %}
 
-<li class="item" id="{{ image.name }}" style="background-image: url('{{ site.baseurl }}photos/tint/{{ image.name }}')">
-	<img class="lazyload" data-src="{{ site.baseurl }}photos/thumbnail/{{ image.name }}" src="{{ site.baseurl }}photos/tint/{{ image.name }}" height="{{ image_path | exif: 'height'}}" width="{{ image_path | exif: 'width'}}" />
+{% capture image_path %}photos/original/{{ image.name }}{% endcapture %}
+{% capture href %}/{{ slug }}/{% endcapture %}
+
+{% if page.url == href %}
+    {% assign target = "target" %}
+{% else %}
+    {% assign target = "" %}
+{% endif %}
+
+<li class="item {{ target }}" id="{{ slug }}" style="background-image: url('{{ safe_name | processed_path: 'tint' }}')" title="{{ image.name | strip_extension }}">
+
+	<img class="lazyload" data-src="{{ safe_name | processed_path: 'thumbnail' }}" src="{{ safe_name | processed_path: 'tint' }}" height="{{ image_path | exif: 'height'}}" width="{{ image_path | exif: 'width'}}" />
 	<span class="full">
-		<span style="background-image: url('{{ site.baseurl }}photos/large/{{ image.name }}')"></span>
+		<span style="background-image: url('{{ safe_name | processed_path: 'large' }}')"></span>
 	</span>
-	<a class="open" href="#{{ image.name }}">Open</a>
-	<a class="close" href="#home">Close</a>
-	<a class="next" href="#next" title="Go to next photo"><span>Next</span></a>
-	<a class="previous" href="#previous" title="Go to previous photo"><span>Previous</span></a>
-	<!-- <ul class="meta">
-		<li>{{ image_path | exif: 'model'}}</li>
-		<li>{{ image_path | exif: 'exposure_time.to_s'}}</li>
-		<li><span class="aperture"><em>f</em>/</span>{{ image_path | exif: 'f_number.to_f'}}</li>
+	<a class="open" href="{{ href  }}" data-target="{{ slug }}">Open</a>
+	<a class="close" href="/">Close</a>
+
+    {% unless forloop.first %}
+    	{% assign previous_slug = images[previous_index].name | strip_extension | slugify %}
+    	<a href="/{{ previous_slug }}/" data-target="{{ previous_slug }}" class="previous" title="Go to previous photo">
+            <span>Previous</span>
+        </a>
+    {% endunless %}
+
+    {% unless forloop.last %}
+    	{% assign next_slug = images[next_index].name | strip_extension | slugify %}
+        <a href="/{{ next_slug }}/" data-target="{{ next_slug }}" class="next" title="Go to next photo">
+            <span>Next</span>
+        </a>
+    {% endunless %}
+
+    <!-- <ul class="meta">
+    <li>{{ image_path | exif: 'model'}}</li>
+    <li>{{ image_path | exif: 'exposure_time.to_s'}}</li>
+    <li><span class="aperture"><em>f</em>/</span>{{ image_path | exif: 'f_number.to_f'}}</li>
 	</ul> -->
 </li>

--- a/_plugins/netlify.rb
+++ b/_plugins/netlify.rb
@@ -1,0 +1,9 @@
+module Jekyll
+  class Netlify < Generator
+    def generate(site)
+      if ENV["CONTEXT"] != "production" && ENV["DEPLOY_PRIME_URL"]
+        site.config['url'] = ENV["DEPLOY_PRIME_URL"]
+      end
+    end
+  end
+end

--- a/_plugins/photo_pages.rb
+++ b/_plugins/photo_pages.rb
@@ -1,0 +1,33 @@
+module Jekyll
+  class PhotoPages < Generator
+    safe true
+
+    def generate(site)
+      site.static_files.each do |file|
+        if file.relative_path.include?("original")
+          site.pages << PhotoPage.new(site, site.source, file)
+        end
+      end
+    end
+  end
+
+  class PhotoPage < Page
+    def initialize(site, base, file)
+      basename = File.basename(file.path)
+      name = File.basename(file.path, ".*")
+      slug = Jekyll::Utils.slugify(name)
+
+      @site = site
+      @base = base
+      @dir  = slug
+      @name = "index.html"
+
+      self.process(@name)
+      self.read_yaml(File.join(base), "index.html")
+
+      self.data["title"] = name
+      self.data["image"] = basename
+      self.data["image_slug"] = slug
+    end
+  end
+end

--- a/_plugins/strip_extension.rb
+++ b/_plugins/strip_extension.rb
@@ -1,0 +1,8 @@
+module Jekyll
+  module StripExtension
+    def strip_extension(text)
+      File.basename(text, ".*")
+    end
+  end
+end
+Liquid::Template.register_filter(Jekyll::StripExtension)

--- a/_plugins/uri_escape.rb
+++ b/_plugins/uri_escape.rb
@@ -1,0 +1,10 @@
+require "uri"
+
+module Jekyll
+  module URIEscape
+    def uri_escape(text)
+      URI.escape(text) if !text.nil?
+    end
+  end
+end
+Liquid::Template.register_filter(Jekyll::URIEscape)

--- a/css/master.scss
+++ b/css/master.scss
@@ -189,11 +189,6 @@ body {
 			}
 		}
 
-		&:first-child .previous,
-		&:last-child .next {
-			display: none !important;
-		}
-
 		.meta {
 			display: flex;
 			position: absolute;
@@ -208,7 +203,7 @@ body {
 			}
 		}
 
-		&:target {
+		&.target {
 			position: fixed;
 			top: 0;
 			right: 0;

--- a/feed.xml
+++ b/feed.xml
@@ -4,13 +4,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 	<generator uri="https://github.com/maxvoltar/maxvoltar-photo">Photo Stream by @maxvoltar</generator>
-	<link href="{{ site.url }}" rel="self" type="application/atom+xml" />
+	<link href="{{ site.url }}/feed.xml" rel="self" type="application/atom+xml" />
 	<link href="{{ site.url }}" rel="alternate" type="text/html"/>
 	<updated>{{ site.time }}</updated>
 	<id>{{ site.url }}</id>
 	<title type="html">{{ site.title}}</title>
 	<subtitle>{{ site.description }}</subtitle>
-
 
 	{% if site.author %}
 		<author>
@@ -25,34 +24,34 @@
 			{% endif %}
 		</author>
 	{% endif %}
-	
+
 	{% assign images = site.static_files | photo_filter %}
-		{% for image in images limit: 20 %}
-			{% capture image_path %}photos/original/{{ image.name }}{% endcapture %}
-			<entry>
-				<title type="html">{{ image.name }}</title>
-				<link href="{{ site.url }}/#{{ image.name }}" rel="alternate" type="text/html" title="{{ image.name }}" />
-				<published>{{ site.time }}</published>
-				<updated>{{ image_path | exif: 'date_time'}}</updated>
-				<id>{{ image.name }}</id>
-				<content type="html" xml:base="{{ site.url }}/#{{ image.name }}">
-					<![CDATA[<figure><a href="{{ site.url }}/#{{ image.name }}"><img src="{{ site.url }}/photos/large/{{ image.name }}" alt="#{{ image.name }}" /></a></figure>]]>
-				</content>
-				{% if site.author %}
-					<author>
-						{% if site.author.name %}
-							<name>{{ site.author.name }}</name>
-						{% endif %}
-						{% if site.author.email %}
-							<email>{{ site.author.email }}</email>
-						{% endif %}
-						{% if site.author.website %}
-							<uri>{{ site.author.website }}</uri>
-						{% endif %}
-					</author>
-				{% endif %}
-				<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ site.url }}/photos/large/{{ image.name }}" />
-				<media:content medium="image" url="{{ site.url }}/photos/large/{{ image.name }}" xmlns:media="http://search.yahoo.com/mrss/" />
-			</entry>
-		{% endfor %}
+	{% for image in images limit: 20 %}
+		{% capture image_path %}photos/original/{{ image.name }}{% endcapture %}
+		<entry>
+			<title type="html">{{ image.name | strip_extension }}</title>
+			<link href="{{ site.url }}/{{ image.name | strip_extension | slugify }}/" rel="alternate" type="text/html" title="{{ image.name | strip_extension }}" />
+			<published>{{ site.time }}</published>
+			<updated>{{ image_path | exif: 'date_time'}}</updated>
+			<id>{{ image.name }}</id>
+			<content type="html">
+				<![CDATA[<figure><a href="{{ site.url }}/{{ image.name | strip_extension | slugify }}/"><img src="{{ site.url }}{{ image.name | uri_escape | processed_path: 'large' }}" alt="{{ image.name | strip_extension }}" /></a></figure>]]>
+			</content>
+			{% if site.author %}
+				<author>
+					{% if site.author.name %}
+						<name>{{ site.author.name }}</name>
+					{% endif %}
+					{% if site.author.email %}
+						<email>{{ site.author.email }}</email>
+					{% endif %}
+					{% if site.author.website %}
+						<uri>{{ site.author.website }}</uri>
+					{% endif %}
+				</author>
+			{% endif %}
+			<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ site.url }}{{ image.name | uri_escape | processed_path: 'large' }}" />
+			<media:content medium="image" url="{{ site.url }}{{ image.name | uri_escape | processed_path: 'large' }}" xmlns:media="http://search.yahoo.com/mrss/" />
+		</entry>
+	{% endfor %}
 </feed>


### PR DESCRIPTION
This is a replacement for #17.

- Switched to JavaScript-based navigation.
- Added jekyll-tidy to clean output HTML.
- Added support for per-page Open Graph tags.
- Added support for Netlify preview URLs.

The image names (without files extensions) are used as the title. A slug is generated to create the URL. Which looks like this:

<img width="1392" alt="Screen Shot 2020-03-08 at 2 59 10 PM" src="https://user-images.githubusercontent.com/133809/76164238-93e73280-614d-11ea-9d0c-b93f9c273d43.png">
